### PR TITLE
fix: 🚚 update nrfconnect repository location

### DIFF
--- a/docs/devices/FOTA.md
+++ b/docs/devices/FOTA.md
@@ -4,7 +4,7 @@
 
 Firmware updates over the Air on AWS are implemented using AWS IoT Jobs,
 following the Nordic
-[FOTA example](https://github.com/NordicPlayground/fw-nrfconnect-nrf/tree/master/samples/nrf9160/aws_fota).
+[FOTA example](https://github.com/nrfconnect/sdk-nrf/tree/master/samples/nrf9160/aws_fota).
 
 ## See also
 

--- a/docs/firmware/BuildingUsingDocker.md
+++ b/docs/firmware/BuildingUsingDocker.md
@@ -8,7 +8,7 @@ The docker image is not intended to be shared, but to simplify building locally.
 It is used to cache all dependencies so you can build and develop locally
 without needing to install dependencies directly in your system.
 
-[Read more about this aproach here](https://github.com/coderbyheart/fw-nrfconnect-nrf-docker).
+[Read more about this aproach here](https://github.com/coderbyheart/sdk-nrf-docker).
 
     git clone https://github.com/bifravst/firmware
     cd firmware

--- a/docs/firmware/BuildingUsingDocker.md
+++ b/docs/firmware/BuildingUsingDocker.md
@@ -8,7 +8,7 @@ The docker image is not intended to be shared, but to simplify building locally.
 It is used to cache all dependencies so you can build and develop locally
 without needing to install dependencies directly in your system.
 
-[Read more about this aproach here](https://github.com/coderbyheart/sdk-nrf-docker).
+[Read more about this aproach here](https://github.com/coderbyheart/fw-nrfconnect-nrf-docker).
 
     git clone https://github.com/bifravst/firmware
     cd firmware

--- a/docs/firmware/GettingStarted.md
+++ b/docs/firmware/GettingStarted.md
@@ -5,7 +5,7 @@
 [![Commitizen friendly](https://img.shields.io/badge/commitizen-friendly-brightgreen.svg)](http://commitizen.github.io/cz-cli/)
 
 The Cat Tracker Firmware is a reference application developed using the
-[nRF Connect SDK](https://github.com/NordicPlayground/fw-nrfconnect-nrf).
+[nRF Connect SDK](https://github.com/nrfconnect/sdk-nrf).
 
 The source code for the Cat Tracker application is available
 [here](https://github.com/bifravst/firmware).

--- a/docs/guides/AutomateHEXFileBuilding.md
+++ b/docs/guides/AutomateHEXFileBuilding.md
@@ -5,7 +5,7 @@
 
 Continuous delivery is in important aspect of short time to market and since the
 nRF9160
-[supports firmware over the air updates](https://github.com/NordicPlayground/fw-nrfconnect-nrf/tree/master/samples/nrf9160/aws_fota) we
+[supports firmware over the air updates](https://github.com/nrfconnect/sdk-nrf/tree/master/samples/nrf9160/aws_fota) we
 want to ship a new firmware to our development boards every time we update the
 application.
 


### PR DESCRIPTION
The nRF Connect repositories have been moved to [a separate GitHub organization](https://github.com/nrfconnect).