### PR TITLE
fix: rename Thingy:91 board identifier

### DIFF
--- a/docs/firmware/BuildingUsingDocker.md
+++ b/docs/firmware/BuildingUsingDocker.md
@@ -20,7 +20,7 @@ without needing to install dependencies directly in your system.
 
 ### Thingy:91 (`PCA20035`)
 
-    docker run --rm -v ${PWD}:/workdir/ncs/firmware bifravst-firmware-docker:latest /bin/bash -c 'cd /workdir/ncs/firmware; west build -p always -b nrf9160_pca20035ns'
+    docker run --rm -v ${PWD}:/workdir/ncs/firmware bifravst-firmware-docker:latest /bin/bash -c 'cd /workdir/ncs/firmware; west build -p always -b thingy91_nrf9160ns'
     ls -la build/zephyr/merged.hex
 
 ### nRF9160 DK (`PCA10090`)

--- a/docs/firmware/BuildingUsingLocalSystem.md
+++ b/docs/firmware/BuildingUsingLocalSystem.md
@@ -39,7 +39,7 @@ build for your board:
 
 ### Thingy:91 (`PCA20035`)
 
-    west build -p always -b nrf9160_pca20035ns
+    west build -p always -b thingy91_nrf9160ns
 
 ### nRF9160 DK (`PCA10090`)
 

--- a/docs/firmware/state.json
+++ b/docs/firmware/state.json
@@ -44,7 +44,7 @@
       "nw": "NB-IoT GPS",
       "iccid": "89450421180216216095",
       "modV": "mfw_nrf9160_1.0.0",
-      "brdV": "nrf9160_pca20035",
+      "brdV": "thingy91_nrf9160",
       "appV": "v1.0.0-rc1-327-g6fc8c16b239f"
     },
     "ts": 1563968743666

--- a/docs/firmware/state.schema.json
+++ b/docs/firmware/state.schema.json
@@ -204,7 +204,7 @@
               "type": "string",
               "description": "Board Version",
               "minLength": 1,
-              "examples": ["nrf9160_pca20035"]
+              "examples": ["thingy91_nrf9160"]
             },
             "appV": {
               "type": "string",


### PR DESCRIPTION
See https://github.com/bifravst/firmware/issues/47
Depends on https://github.com/bifravst/firmware/pull/49